### PR TITLE
Re-calculate depreciation rate columns

### DIFF
--- a/src/pudl_rmi/deprish.py
+++ b/src/pudl_rmi/deprish.py
@@ -992,6 +992,8 @@ def agg_to_idx(deprish_df, idx_cols):
                 "average version than expect. Check the methodology in "
                 "_fill_in_rate_cols()"
             )
+    # now that we've check these old columns we can remove Thermal
+    deprish_asset = deprish_asset.drop(columns=[f"{c}_old" for c in calc_cols])
 
     deprish_asset = deprish_asset.convert_dtypes(convert_floating=False)
     return deprish_asset

--- a/src/pudl_rmi/deprish.py
+++ b/src/pudl_rmi/deprish.py
@@ -932,8 +932,10 @@ def agg_to_idx(deprish_df, idx_cols):
         sum_cols = DOLLAR_COLS + [f"{x}_w{COMMON_SUFFIX}" for x in DOLLAR_COLS]
         suffix = f'_w{COMMON_SUFFIX}'
     # aggregate the columns that can be summed..
-    deprish_asset = deprish_df.groupby(by=idx_cols, dropna=False)[
-        sum_cols].sum(min_count=1)
+    deprish_asset = (
+        deprish_df.groupby(by=idx_cols, as_index=False, dropna=False)
+        [sum_cols].sum(min_count=1)
+    )
 
     calc_cols = ['net_salvage_rate', 'reserve_rate',
                  'remaining_life_avg', 'depreciation_annual_rate']


### PR DESCRIPTION
### Overall depreciation processing context
The depreciation data is processed via `deprish.py`. The main transform method is `Transformer.execute()`, which has four steps:
* **early tidy** which mostly cleans data types and preforms minor data adjustments.
* **reshape** which rn allocates the "common" records - records which are associated with a full plant or group of plant-parts such as the land value of a plant - to their "atomic" record (i.e. the non-common plant-part records).
* **fill in** which calculates missing values. Many of the original depreciation studies do not have all of the data columns that are commonly need to analysis, but generally they have enough of the value to calculate the missing data points (i.e. one study will have a depreciation rate but no annual depreciation cost and vice versa).
* **aggregate**. Many of  the depreciation studies include the very detailed records for each FERC account # - which are accounting categories. This means many plant-part's have a record for every FERC account #. This is a level of detail which we basically never need, so we aggregate the output to the plant-part level.

### What we were previously doing
The RMI team wanted us to recalculate the slew of "rate" columns at the end of the aggregation step. Previously, we were calculating these rate columns through applying a weighted average. Applying a weighted average was nice because it was based on the original data, but it was causing the final output to be internally inconsistent. If you were to use one of these rate columns to attempt to recalculate a value (such as annual depreciation), you would not always get the value for annual depreciation. The choice of which column to weight based on was also somewhat arbitrary. This was also somewhat muddled because we were not allocating the common values for these rate columns in the **reshape** step.

### The new methodology
Now, we are recalculating these derivable values in the aggregate step so the output is internally consistent. I did this by extracting the **fill in** methodology for these rate columns from the standard **fill in** process so the same methodology can be used in the **fill in** step and the **aggregate** step.

I added a little check that will output how different these derivable columns are from the previous weighted average methodology. I could remove a lot of the lines in here if we determine this is not needed.... It would certainly clean up the function. And the more I enumerate how what we were doing previously was weird I lean towards removing this.
