### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/pre-commit-ci-auto-merge.yaml
+++ b/.github/workflows/pre-commit-ci-auto-merge.yaml
@@ -1,0 +1,18 @@
+name: pre-commit-ci-auto-merge
+
+on:
+  workflow_run:
+    types: [completed]
+    workflows: ['tox-pytest']
+
+jobs:
+  bot-auto-merge:
+    name: Auto-merge passing pre-commit-ci PRs
+    runs-on: ubuntu-latest
+    steps:
+    - name: Auto-merge passing pre-commit-ci PRs
+      if: ${{ github.event.workflow_run.conclusion == 'success' }}
+      uses: ridedott/merge-me-action@v2
+      with:
+        GITHUB_LOGIN: pre-commit-ci
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -3,7 +3,7 @@ name: tox-pytest
 on: [ push, pull_request ]
 
 jobs:
-  build:
+  ci-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -71,6 +71,11 @@ jobs:
         verbose: true
         files: ./coverage.xml
 
+  ci-notify:
+    runs-on: ubuntu-latest
+    needs: ci-test
+    if: ${{ always() }}
+    steps:
     - name: Inform the Codemonkeys
       uses: 8398a7/action-slack@v3
       with:
@@ -81,12 +86,22 @@ jobs:
             username: 'action-slack',
             icon_emoji: ':octocat:',
             attachments: [{
-              color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-              text: `${process.env.AS_WORKFLOW}\n${process.env.AS_JOB} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.AS_REF} by ${process.env.AS_AUTHOR} ${{ job.status }} in ${process.env.AS_TOOK}`,
+              color: '${{ needs.ci-test.result }}' === 'success' ? 'good' : '${{ needs.ci-test.result }}' === 'failure' ? 'danger' : 'warning',
+              text: `${process.env.AS_REPO}@${process.env.AS_REF}\n ${process.env.AS_WORKFLOW} (${process.env.AS_COMMIT})\n by ${process.env.AS_AUTHOR}\n Status: ${{ needs.ci-test.result }}`,
             }]
           }
       env:
         GITHUB_TOKEN: ${{ github.token }} # required
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
         MATRIX_CONTEXT: ${{ toJson(matrix) }} # required
-      if: ${{ always() && github.actor != 'dependabot[bot]' }}
+
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    needs: ci-test
+    if: ${{ needs.ci-test.result == 'success' }}
+    steps:
+      - name: Automerge passing dependabot PR
+        uses: ridedott/merge-me-action@v2
+        with:
+          GITHUB_LOGIN: dependabot  # For clarity only. dependabot is default.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@ repos:
   - id: python-check-blanket-noqa   # Prohibit overly broad QA exclusions.
   - id: python-no-eval              # Never use eval() it's dangerous.
   - id: python-no-log-warn          # logger.warning(), not old .warn()
+  - id: rst-backticks               # Find single rather than double backticks
+  - id: rst-directive-colons        # Missing double-colons after directives
+  - id: rst-inline-touching-normal  # Inline code should never touch normal text
+  - id: python-use-type-annotations # Use annotations not old-style type comments
+
 
 # Other file formatting, plus common Git mistakes & text file standardization:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -22,18 +27,53 @@ repos:
   - id: trailing-whitespace     # Remove trailing whitespace.
   - id: name-tests-test         # Follow PyTest naming convention.
 
-# Format the code
-- repo: https://github.com/psf/black
-  rev: 22.3.0
+########################################################################################
+# Formatters: hooks that re-write Python and RST files
+########################################################################################
+# Convert relative imports to absolute imports
+- repo: https://github.com/MarcoGorelli/absolufy-imports
+  rev: v0.3.1
   hooks:
-  - id: black
-    language_version: python3.10
+  - id: absolufy-imports
 
 # Make sure import statements are sorted uniformly.
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:
   - id: isort
+
+# Remove f-string prefix when there's nothing in the string to format.
+- repo: https://github.com/dannysepler/rm_unneeded_f_str
+  rev: v0.1.0
+  hooks:
+  - id: rm-unneeded-f-str
+
+# Use built-in types for annotations as per PEP585, with __futures__ for Python 3.8/3.9
+# Note that this sometimes conflicts with Pydantic on Python 3.8/3.9
+- repo: https://github.com/sondrelg/pep585-upgrade
+  rev: 'v1.0'
+  hooks:
+  - id: upgrade-type-hints
+    args: ['--futures=true']
+
+# Update a bunch of Python syntax, using __futures__ for Python 3.8/3.9
+# Note that this sometimes conflicts with Pydantic on Python 3.8/3.9
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.32.1
+  hooks:
+  - id: pyupgrade
+    args: ['--py38-plus']
+
+# Deterministic python formatting:
+- repo: https://github.com/psf/black
+  rev: 22.3.0
+  hooks:
+  - id: black
+    language_version: python3.10
+
+########################################################################################
+# Linters: hooks that check but don't alter Python & RST files
+########################################################################################
 
 # Check for PEP8 non-compliance, code complexity, style, errors, etc:
 - repo: https://github.com/PyCQA/flake8
@@ -52,3 +92,18 @@ repos:
       - pyflakes
       - flake8-rst-docstrings
       - flake8-use-fstring
+
+########################################################################################
+# Configuration for pre-commit.ci
+########################################################################################
+ci:
+  autofix_commit_msg: |
+    [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+    For more information, see https://pre-commit.ci
+  autofix_prs: true
+  autoupdate_branch: main
+  autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+  autoupdate_schedule: weekly
+  skip: [unit-tests, nb-output-clear]
+  submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,5 +121,4 @@ ci:
   autoupdate_branch: main
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
   autoupdate_schedule: weekly
-  skip: [unit-tests, nb-output-clear]
   submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,22 @@ repos:
       - flake8-rst-docstrings
       - flake8-use-fstring
 
+# Check for errors in restructuredtext (.rst) files under the doc hierarchy
+- repo: https://github.com/PyCQA/doc8
+  rev: 0.11.2
+  hooks:
+  - id: doc8
+    args: ['--config', 'tox.ini']
+
+# Lint any RST files and embedded code blocks for syntax / formatting errors
+- repo: https://github.com/myint/rstcheck
+  rev: v6.0.0rc1
+  hooks:
+  - id: rstcheck
+    additional_dependencies: [sphinx]
+    args: ['--config', 'tox.ini']
+
+
 ########################################################################################
 # Configuration for pre-commit.ci
 ########################################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<60.0.0", "pip", "wheel"]
+requires = ["setuptools<62", "pip", "wheel"]
 
 [tool.black]
 line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
             "pre-commit>=2.9,<3",
             "pytest>=6.2,<8.0",
             "pytest-cov>=2.10,<4",
+            "rstcheck>=5,<6",
             "tox>=3.20,<4",
         ]
     },

--- a/src/pudl_rmi/connect_deprish_to_ferc1.py
+++ b/src/pudl_rmi/connect_deprish_to_ferc1.py
@@ -54,9 +54,10 @@ Future Needs:
   allocate or aggregate an input record.
 
 """
+from __future__ import annotations
 
 import logging
-from typing import Dict, List, Literal, Optional
+from typing import Literal
 
 import pandas as pd
 import pudl
@@ -66,13 +67,13 @@ from pudl_rmi import make_plant_parts_eia
 
 logger = logging.getLogger(__name__)
 
-SCALE_CAP_GEN_COST: "FieldTreatment" = {
+SCALE_CAP_GEN_COST: FieldTreatment = {
     "treatment_type": "scale",
     "allocator_cols": ["capacity_mw", "net_generation_mwh", "total_fuel_cost"],
 }
 
 
-META_DEPRISH_EIA: Dict[str, "FieldTreatment"] = {
+META_DEPRISH_EIA: dict[str, FieldTreatment] = {
     "line_id": {"treatment_type": "str_concat"},
     "plant_balance_w_common": SCALE_CAP_GEN_COST,
     "book_reserve_w_common": SCALE_CAP_GEN_COST,
@@ -92,7 +93,7 @@ META_DEPRISH_EIA: Dict[str, "FieldTreatment"] = {
 }
 
 
-META_FERC1_EIA: Dict[str, "FieldTreatment"] = {
+META_FERC1_EIA: dict[str, FieldTreatment] = {
     "record_id_ferc1": {"treatment_type": "str_concat"},
     "capex_total": SCALE_CAP_GEN_COST,
     "capex_annual_addition": SCALE_CAP_GEN_COST,
@@ -320,8 +321,8 @@ class FieldTreatment(BaseModel):
 
     """
 
-    allocator_cols: Optional[List[str]]
-    wtavg_col: Optional[str]
+    allocator_cols: list[str] | None
+    wtavg_col: str | None
 
     treatment_type: Literal["scale", "str_concat", "wtavg"]
 
@@ -349,12 +350,12 @@ class PlantPartScaler(BaseModel):
 
     """
 
-    treatments: Dict[str, FieldTreatment]
-    ppe_pk: List[str] = ["record_id_eia"]
-    data_set_pk_cols: List[str]
+    treatments: dict[str, FieldTreatment]
+    ppe_pk: list[str] = ["record_id_eia"]
+    data_set_pk_cols: list[str]
     plant_part: Literal["plant_gen"]
 
-    def _get_treatment_cols(self, treatment_type: str) -> List[str]:
+    def _get_treatment_cols(self, treatment_type: str) -> list[str]:
         """Grab the columns which need a specific treatment type."""
         return [
             col
@@ -363,7 +364,7 @@ class PlantPartScaler(BaseModel):
         ]
 
     @property
-    def wtavg_dict(self) -> Dict:
+    def wtavg_dict(self) -> dict:
         """Grab the dict of columns that get a weighted average treatment."""
         return {
             wtavg_col: self.treatments[wtavg_col].wtavg_col
@@ -371,7 +372,7 @@ class PlantPartScaler(BaseModel):
         }
 
     @property
-    def allocator_cols_dict(self) -> Dict:
+    def allocator_cols_dict(self) -> dict:
         """Grab the columns from the metadata which need to be allocated."""
         return {
             allocate_col: self.treatments[allocate_col].allocator_cols
@@ -547,7 +548,7 @@ class PlantPartScaler(BaseModel):
         return df_out
 
     def broadcast_merge_to_plant_part(
-        self, data_to_scale: pd.DataFrame, cols_to_keep: List[str], ppe: pd.DataFrame
+        self, data_to_scale: pd.DataFrame, cols_to_keep: list[str], ppe: pd.DataFrame
     ) -> pd.DataFrame:
         """
         Broadcast data with a variety of granularities to a single plant-part.
@@ -642,7 +643,7 @@ def str_concat(x):
 
 
 def _allocate_col(
-    to_allocate: pd.DataFrame, by: list, allocate_col: str, allocator_cols: List[str]
+    to_allocate: pd.DataFrame, by: list, allocate_col: str, allocator_cols: list[str]
 ) -> pd.Series:
     """
     Allocate larger dataset records porportionally by EIA plant-part columns.

--- a/src/pudl_rmi/create_override_spreadsheets.py
+++ b/src/pudl_rmi/create_override_spreadsheets.py
@@ -13,9 +13,11 @@ functions that will read those new/updated/validated matches from the spreadshee
 validate them, and incorporate them into the existing training data.
 
 """
+from __future__ import annotations
+
 import logging
 import os
-from typing import Dict, List, Literal
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -25,7 +27,7 @@ import pudl_rmi
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-RENAME_COLS_FERC_EIA: Dict = {
+RENAME_COLS_FERC_EIA: dict = {
     "new_1": "verified",
     "new_2": "used_match_record",
     "new_3": "signature_1",
@@ -77,7 +79,7 @@ RENAME_COLS_FERC_EIA: Dict = {
     "new_17": "installation_year_diff",
 }
 
-RELEVANT_COLS_PPL: List = [
+RELEVANT_COLS_PPL: list = [
     "record_id_eia",
     "report_year",
     "utility_id_pudl",

--- a/src/pudl_rmi/deprish.py
+++ b/src/pudl_rmi/deprish.py
@@ -399,7 +399,7 @@ class Transformer:
         # and decimal rates (i.e. .882 for 88.2%).
         # numbers of decimals (e.g. 88.2% would either be represented as
         # 88.2 or .882). Some % columns have boolean columns (ending in
-        # type_pct) that we fleshed out to know wether the values were
+        # "type_pct") that we fleshed out to know wether the values were
         # reported as numbers or %s.
         to_num_cols = ["net_salvage_rate", "reserve_rate", "depreciation_annual_rate"]
         for col in to_num_cols:
@@ -701,7 +701,7 @@ class Transformer:
         # to fill it in, but drop all the other columns and merge them back in
         # after we are done using the weight_col
         # sometimes we are allocating the weight_col so we don't want doubles
-        cols = list(set([weight_col, split_col]))
+        cols = list({weight_col, split_col})
         filled_df = self.fill_in_df(deprish_w_c, common_allocated=False)[
             IDX_COLS_DEPRISH + cols + [f"{split_col}{COMMON_SUFFIX}"]
         ]

--- a/src/pudl_rmi/formatter_optimus.py
+++ b/src/pudl_rmi/formatter_optimus.py
@@ -1,13 +1,14 @@
 """Convert RMI outputs into model output format."""
+from __future__ import annotations
 
 import logging
-from typing import Dict, List, Literal
+from typing import Literal
 
 import pandas as pd
 
 logger = logging.getLogger(__name__)
 
-RENAME_COLS: Dict = {
+RENAME_COLS: dict = {
     "record_id_eia": "Unique_ID",
     "faked_1": "Scenario_Short",
     "utility_name_eia": "Utility",
@@ -112,7 +113,7 @@ RENAME_COLS: Dict = {
     "ferc_acct_name": "FERC Acct",
 }
 
-TECHNOLOGY_DESCRIPTION_TO_RESOURCE_TYPE: Dict = {
+TECHNOLOGY_DESCRIPTION_TO_RESOURCE_TYPE: dict = {
     "Conventional Steam Coal": "Coal",
     "Natural Gas Fired Combined Cycle": "NaturalGasCC",
     "Natural Gas Fired Combustion Turbine": "NaturalGasCT",
@@ -131,7 +132,7 @@ TECHNOLOGY_DESCRIPTION_TO_RESOURCE_TYPE: Dict = {
     # pd.NA: 'Battery'
 }
 
-UTILITY_RENAME: Dict = {
+UTILITY_RENAME: dict = {
     "Carolina Power & Light Co": "Duke Energy Progress",
     "Duke Energy Corp": "Duke Energy Carolinas",
 }
@@ -206,8 +207,8 @@ def execute(
 
 def select_from_deprish_ferc1(
     deprish_ferc1_eia: pd.DataFrame,
-    util_id_pudls: List[int],
-    years: List[int],
+    util_id_pudls: list[int],
+    years: list[int],
     priority_data_source: Literal["PUC", "FERC"] = "PUC",
     include_non_priority_data_source: bool = True,
 ) -> pd.DataFrame:

--- a/src/pudl_rmi/validate.py
+++ b/src/pudl_rmi/validate.py
@@ -1,7 +1,7 @@
 """A module for data validation and QA/QC of the RMI outputs."""
+from __future__ import annotations
 
 import logging
-from typing import List
 
 import numpy as np
 import pandas as pd
@@ -115,7 +115,7 @@ def add_data_source(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def group_sum_cols(df, data_cols: List[str], by: List[str]) -> pd.DataFrame:
+def group_sum_cols(df, data_cols: list[str], by: list[str]) -> pd.DataFrame:
     """Groupby sum a specific table's data cols."""
     # convert date to year bc many of the og depish studies are EOY
     summed_out = (
@@ -128,7 +128,7 @@ def group_sum_cols(df, data_cols: List[str], by: List[str]) -> pd.DataFrame:
 
 
 def agg_test_data(
-    df1: pd.DataFrame, df2: pd.DataFrame, data_cols: List[str], by: List[str], **kwargs
+    df1: pd.DataFrame, df2: pd.DataFrame, data_cols: list[str], by: list[str], **kwargs
 ) -> pd.DataFrame:
     """
     Merge two grouped input tables to determine if summed data column are equal.
@@ -180,7 +180,7 @@ def agg_test_data(
 def compare_df_vs_net_plant_balance(
     df: pd.DataFrame,
     net_plant_balance: pd.DataFrame,
-    data_cols: List = [
+    data_cols: list = [
         "plant_balance_w_common",
         "book_reserve_w_common",
         "unaccrued_balance_w_common",

--- a/test/integration/rmi_out_test.py
+++ b/test/integration/rmi_out_test.py
@@ -3,9 +3,10 @@ Test whether all of the FERC1/EIA/Depreciation outputs can be generated.
 
 This can take up to an hour to run.
 """
+from __future__ import annotations
 
 import logging
-from typing import List, Literal
+from typing import Literal
 
 import pandas as pd
 import pytest
@@ -136,7 +137,7 @@ def test_consistency_of_data_stages(
     rmi_out: pudl_rmi.coordinate.Output,
     df1_name: str,
     df2_name: str,
-    data_cols: List[str],
+    data_cols: list[str],
     by_name: Literal["plants", "utilities"],
 ):
     """

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,10 @@ doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS
 # * W503, W504: Line break before / after binary operator.
 # * D401: Imperative mood.
 # * E501: Overlong line
+# * E203: Space before ':' (black recommends to ignore)
+# * RST201,RST203,RST301: Google docstrings aren't RST until after being processed by
+#   Napoleon. See https://github.com/peterjc/flake8-rst-docstrings/issues/17
+extend-ignore = W503,W504,D401,E501,E203,RST201,RST203,RST301,
 ignore = W503,W504,D401,E501,E203
 inline-quotes = double
 max-line-length = 88
@@ -109,10 +113,6 @@ extend-exclude =
 # We have a backlog of complex functions being skipped with noqa: C901
 max-complexity = 10
 format = ${cyan}%(path)s${reset}:${green}%(row)-4d${reset} ${red_bold}%(code)s${reset} %(text)s
-extend-ignore =
-# Google Python style is not RST until after processed by Napoleon
-# See https://github.com/peterjc/flake8-rst-docstrings/issues/17
-    RST201,RST203,RST301,
 rst-roles =
     attr,
     class,
@@ -129,3 +129,14 @@ rst-directives =
     exception,
 percent-greedy = 2
 format-greedy = 2
+
+[doc8]
+max-line-length = 88
+ignore-path =
+    docs/_build
+
+[rstcheck]
+report_level = warning
+ignore_roles = pr,issue,user
+ignore_messages = (Hyperlink target ".*" is not referenced\.$|Duplicate implicit target name:)
+ignore_directives = bibliography,todo


### PR DESCRIPTION
Add some of the newer CI changes from `cheshire` into the RMI repo, including:
* autoformatters that help with type hints and modernizing python syntax.
* separate `ci-test` and `ci-notify` jobs.
* Configuration for the `pre-commit-ci` service.
* Bot automerge workflows for `pre-commit-ci` and `dependabot`
* RST linters
* Additional simple built-in pre-commit & pygrep hooks.