### PR TITLE
Add a net plant balance into deprecaition processing! (and don't confuse it w/ unaccrued balance)

### DIFF
--- a/src/pudl_rmi/connect_deprish_to_eia.py
+++ b/src/pudl_rmi/connect_deprish_to_eia.py
@@ -258,7 +258,7 @@ def add_overrides(deprish_match, file_path_deprish, sheet_name_output):
             .any(axis="columns")
         ][
             RESTRICT_MATCH_COLS
-            + ["plant_part_name", "data_source"]
+            + ["plant_part_name", "data_source", "line_id"]
             + list(overrides_df.filter(like="record_id_eia_override").columns)
         ]
         logger.info(f"Adding {len(overrides_df)} overrides from {sheet_name_output}.")
@@ -267,7 +267,7 @@ def add_overrides(deprish_match, file_path_deprish, sheet_name_output):
             pd.merge(
                 deprish_match.convert_dtypes(convert_floating=False),
                 overrides_df.convert_dtypes(convert_floating=False),
-                on=RESTRICT_MATCH_COLS + ["plant_part_name", "data_source"],
+                on=RESTRICT_MATCH_COLS + ["plant_part_name", "data_source", "line_id"],
                 how="outer",
             )
             .drop_duplicates()

--- a/src/pudl_rmi/connect_deprish_to_ferc1.py
+++ b/src/pudl_rmi/connect_deprish_to_ferc1.py
@@ -77,6 +77,7 @@ META_DEPRISH_EIA: Dict[str, "FieldTreatment"] = {
     "plant_balance_w_common": SCALE_CAP_GEN_COST,
     "book_reserve_w_common": SCALE_CAP_GEN_COST,
     "unaccrued_balance_w_common": SCALE_CAP_GEN_COST,
+    "net_plant_balance_w_common": SCALE_CAP_GEN_COST,
     "net_salvage_w_common": SCALE_CAP_GEN_COST,
     "depreciation_annual_epxns_w_common": SCALE_CAP_GEN_COST,
     "depreciation_annual_rate": {

--- a/src/pudl_rmi/coordinate.py
+++ b/src/pudl_rmi/coordinate.py
@@ -231,7 +231,13 @@ class Output:
         file_path = pudl_rmi.DEPRISH_FERC1_PKL
         # if any of the clobbers are on, we want to regenerate the main output
         clobber_any = any(
-            [clobber, clobber_plant_parts_eia, clobber_deprish_eia, clobber_ferc1_eia]
+            [
+                clobber,
+                clobber_deprish,
+                clobber_plant_parts_eia,
+                clobber_deprish_eia,
+                clobber_ferc1_eia,
+            ]
         )
         check_is_file_or_not_exists(file_path)
 

--- a/src/pudl_rmi/deprish.py
+++ b/src/pudl_rmi/deprish.py
@@ -190,6 +190,9 @@ class Transformer:
             # read in the depreciation sheet, assign types when required
             # we need the dtypes assigned early in this process because the
             # next steps involve splitting and filling in the null columns.
+            # the net_plant_balance doesn't exist in the studies, but we make
+            # it here as a null column to be filled in later because it is an
+            # expected column in many transformations bc it is in DOLLAR_COLS
             self.tidy_df = (
                 self.extract_df.assign(net_plant_balance=pd.NA)
                 .convert_dtypes(convert_floating=False)

--- a/src/pudl_rmi/formatter_optimus.py
+++ b/src/pudl_rmi/formatter_optimus.py
@@ -35,7 +35,7 @@ RENAME_COLS: Dict = {
     "remaining_life_avg": "Current Remaining Accounting Life (Yrs)",
     "plant_balance_w_common": "Gross Plant Balance/Original Cost ($)",
     "book_reserve_w_common": "Book Reserve/Accumulated Depreciation ($)",
-    "unaccrued_balance_w_common": "Current Net Plant Balance ($)",
+    "net_plant_balance_w_common": "Current Net Plant Balance ($)",
     "depreciation_annual_epxns_w_common": "Annual Depreciation Expense ($)",
     "depreciation_annual_rate": "Depreciation Rate (%)",
     "net_salvage_w_common": "Decommissioning Cost ($)",


### PR DESCRIPTION
WE HAD IT ALL WRONG! lol, no but sort of. Previously, we were assuming "net plant balance" and "unaccrued balance" were the same thing. They are not. lil example calcs:
* net plant balance = plant balance (original cost) - book reserve
* unaccrued balance = plant balance (original cost) - book reserve - net salvage

Soooo I've added a new net plant balance column that is always calculated in the `deprish.py` module.

There are twp downstream impacts:
* include the net plant balance in `connect_deprish_to_ferc1` via the treated field dictionaries
* in `formatter_optimus` swap the column we are calling net plant balance to be.... 🥁☸️ .... net plant balance!

Two little extras that snuck in:
* [see commit](https://github.com/catalyst-cooperative/rmi-ferc1-eia/pull/243/commits/ee24da056c7817c08480dee5d7639c74428ac58c)
* [see commit](https://github.com/catalyst-cooperative/rmi-ferc1-eia/pull/243/commits/5d88e18e026b48caa9d2778046c53b63513de90f)
 

closes #234