### PR TITLE
Resolve pandera dependencies preventing conda from solving the environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - jupyter-resource-usage>=0.5,<1
 
   # Visualization and data validation packages used interactively but not required.
-  - pandera~=0.7.2
+  - pandera~=0.9
   - seaborn~=0.11.2
   - plotly==5.4.0
 


### PR DESCRIPTION
When I tried to create this environment on my machine to try out the EQR ETL, I ran into a problem getting the thing to solve. I was able to get it to create the environment by updating the version of pandera. We use pandera 0.9 on the hub and that seemed to work here too. I think the older version of a pandera depends on versions of packages (simpleeval I believe) that are not available. Maybe an ARM Mac thing, not exactly sure.